### PR TITLE
Fix displayed code coverage

### DIFF
--- a/lib/flutter_coverage/plugin.rb
+++ b/lib/flutter_coverage/plugin.rb
@@ -48,7 +48,7 @@ module Danger
                 covered_lines += line.sub('LH:', '').to_f
             end
         end
-        covered_lines / uncovered_lines
+        covered_lines / uncovered_lines * 100
       end
       
     def code_coverage_message


### PR DESCRIPTION
## Description: 
Currently Netguru hound posts wrong code coverage percentage under PRs.
Code coverage is calculated based on the ratio covered to total code lines.

Example
coverage = covered / total
0.20 = 20/100 (to get percentage we need to multiply by 100)

&& '0.20%' != '20%'

### Displayed message now:
Code coverage: 0.20% ✅"

### Displayed message after fix:
Code coverage: 20.00% ✅"